### PR TITLE
Refact all terms reports

### DIFF
--- a/src/readme_reports_generation.py
+++ b/src/readme_reports_generation.py
@@ -44,6 +44,7 @@ def generate_template_readme(file_name, table):
 
   template.new_header(level=2, title="Blank ontology ID", add_table_of_contents='y')
   template.new_paragraph(text="This report provides a list of blank spreadsheet cells that often mean no ontology mapping found by the author. However, in some cases, a term with a synonym already exists. Please search in [OLS](https://www.ebi.ac.uk/ols/index).")
+  template.new_paragraph(text="You can find more information on the [New CL terms](#new-cl-terms) or [New UBERON terms](#new-uberon-terms) reports.")
   template.new_line()
   template.new_line()
   
@@ -139,45 +140,83 @@ def get_row_link(table, row):
 
   return URL
 
-def generate_invalid_terms_report(log_dict, table):
-
-  terms_report = {"no_found_id": "", "typos": "", "diff_label": "", "blank": "", "external": "", "no_parent": ""}
-
-  for issue in log_dict["no_valid_id"]:
-    if issue["id"] == "": 
-      terms_report["blank"] += f'1. In row _[{issue["row_number"]}]({get_row_link(table, issue["row_number"])})_, no term id was found for the name/label _{issue["user_label"]}_.\n\n'
-    elif 'uberon' in issue["id"] or 'UBERON' in issue["id"] or 'cl' in issue["id"] or 'CL' in issue["id"]:
-      terms_report["typos"] += f'1. In row _[{issue["row_number"]}]({get_row_link(table, issue["row_number"])})_, it might have a typo in the term _{issue["id"]}_. The term id should have this pattern: UBERON:NNNNNNN or CL:NNNNNNN or PCL:NNNNNNN. The ontology name in upper case. N is a number and it should have exact 7 numbers after the colon. Please change it in the ASCT+B table.\n\n'
-    elif 'FMA' in issue["id"] or 'fma' in issue["id"] or 'LMHA' in issue["id"] or 'lmha' in issue["id"] or 'ILX' in issue["id"]:
-      terms_report["external"] += f'1. In row _[{issue["row_number"]}]({get_row_link(table, issue["row_number"])})_, the term _{issue["id"]}_ is from another ontology that is not validated in this process.\n\n'
-  
-  if terms_report["blank"] == "":
-    terms_report["blank"] = "- No issues found.\n\n"
-
-  if terms_report["typos"] == "":
-    terms_report["typos"] = "- No issues found.\n\n"
-
-  if terms_report["external"] == "":
-    terms_report["external"] = "- No issues found.\n\n"
-  
-  for issue in log_dict["no_found_id"]:
-    terms_report["no_found_id"] += f'1. {issue["id"]}\n\n'
-
-  if terms_report["no_found_id"] == "":
-    terms_report["no_found_id"] = "- No issues found.\n\n"
-  
-  for issue in log_dict["diff_label"]:       
-    terms_report["diff_label"] += f'1. In row _[{issue["rowNumber"]}]({get_row_link(table, issue["rowNumber"])})_, the term _{add_base_iri(issue["id"])}_ has different name/label in the source ontology. The name/label in the **ASCT+B table** is _{issue["asct_label"]}_ and the one in the **ontology** is _{issue["label"]}_. For reference, the given name/label **by SMEs** is _{issue["user_label"]}_. Please correct it in the columns AS/N/LABEL or CT/N/LABEL in the ASCT+B table.\n\n'
-  
-  if terms_report["diff_label"] == "":
-    terms_report["diff_label"] = "- No issues found.\n\n"
+def compact_issues(items: list, element: str):
+    compacted_items = {}
     
-  for issue in log_dict["no_parent"]:
-    terms_report["no_parent"] += f'1. In row _[{issue["row_number"]}]({get_row_link(table, issue["row_number"])})_, the term _{issue["user_label"]}_ without ontology ID has no parent that is from the CL ontology.\n\n'
+    for item in items:
+        key = item[element]
+        
+        if key not in compacted_items:
+            compacted_items[key] = item.copy()
+            compacted_items[key]["rows"] = [item["row_number"]]
+            compacted_items[key].pop("row_number")
+        else:
+            compacted_items[key]["rows"].append(item["row_number"])
+    
+    return list(compacted_items.values())
 
-  if terms_report["no_parent"] == "":
-    terms_report["no_parent"] = "- No issue found.\n\n"
-  return terms_report
+def list_rows_link(table: str, rows: list):
+    return (", ").join(list(map(lambda x: f'_[{x}]({get_row_link(table, x)})_', rows)))
+
+def generate_invalid_terms_report(log_dict, table):
+    terms_report = {
+        "no_found_id": "",
+        "typos": "",
+        "diff_label": "",
+        "blank": "",
+        "external": "",
+        "no_parent": ""
+    }
+    
+    blank = []
+    typos = []
+    external = []
+
+    def add_issue_to_report(issue_list, report_key, message_template):
+        if issue_list:
+            compacted_issues = compact_issues(issue_list, "id" if report_key == "typos" or report_key == "external" else "user_label")
+            for issue in compacted_issues:
+                rows = list_rows_link(table, issue["rows"])
+                terms_report[report_key] += message_template.format(
+                    issue_id=issue.get("id", ""),
+                    user_label=issue.get("user_label", ""),
+                    asct_label=issue.get("asct_label", ""),
+                    label=issue.get("label", ""),
+                    rows_count=len(issue["rows"]),
+                    rows_s_or_p="rows" if len(issue["rows"]) > 1 else "row",
+                    rows=rows
+                )
+        else:
+            terms_report[report_key] = "- No issues found.\n\n"
+    
+    for issue in log_dict["no_valid_id"]:
+        if issue["id"] == "":
+            blank.append(issue)
+        elif 'uberon' in issue["id"] or 'UBERON' in issue["id"] or 'cl' in issue["id"] or 'CL' in issue["id"]:
+            typos.append(issue)
+        elif 'FMA' in issue["id"] or 'fma' in issue["id"] or 'LMHA' in issue["id"] or 'lmha' in issue["id"] or 'ILX' in issue["id"]:
+            external.append(issue)
+
+    add_issue_to_report(blank, "blank",
+                        "1. No term id was found for the name/label _{user_label}_ in the following {rows_count} {rows_s_or_p} {rows}.\n\n")
+    
+    add_issue_to_report(typos, "typos",
+                        "1. It might have a typo in the term _{issue_id}_ in the following {rows_count} {rows_s_or_p} {rows}. The term id should have this pattern: UBERON:NNNNNNN or CL:NNNNNNN or PCL:NNNNNNN. The ontology name in upper case. N is a number, and it should have exactly 7 numbers after the colon. Please change it in the ASCT+B table.\n\n")
+    
+    add_issue_to_report(external, "external",
+                        "1. The term _{issue_id}_ in the following {rows_count} {rows_s_or_p} {rows} is from another ontology that is not validated in this process.\n\n")
+
+    add_issue_to_report(log_dict["diff_label"], "diff_label",
+                        "1. The term _{issue_id}_ has a different name/label in the source ontology in the following {rows_count} {rows_s_or_p} {rows}. The name/label in the **ASCT+B table** is _{asct_label}_ and the one in the **ontology** is _{label}_. For reference, the given name/label **by SMEs** is _{user_label}_. Please correct it in the columns AS/N/LABEL or CT/N/LABEL in the ASCT+B table.\n\n")
+
+    add_issue_to_report(log_dict["no_parent"], "no_parent",
+                        "1. The term _{user_label}_ without ontology ID has no parent that is from the CL ontology in the following {rows_count} {rows_s_or_p} {rows}.\n\n")
+    
+    for issue in log_dict["no_found_id"]:
+        terms_report["no_found_id"] += f'1. {issue["id"]}\n\n'
+
+    return terms_report
+
 
 def add_base_iri(content):
   UBERON_BASE = "http://purl.obolibrary.org/obo/UBERON_"

--- a/src/template_generation_tools.py
+++ b/src/template_generation_tools.py
@@ -149,13 +149,13 @@ def generate_class_graph_template(ccf_tools_df :pd.DataFrame, log_dict: dict):
   for term, label in terms_labels:
     row = ccf_tools_df[(ccf_tools_df['s'] == term) | (ccf_tools_df['o'] == term)].iloc[0]
     if row['s'] == term and row['slabel'].lower() != label.lower():
-      log_dict["diff_label"].append({"id": term, "label": label, "asct_label": row['slabel'], "user_label": row['user_slabel'], "rowNumber": int(row['row_number'])})
+      log_dict["diff_label"].append({"id": term, "label": label, "asct_label": row['slabel'], "user_label": row['user_slabel'], "row_number": int(row['row_number'])})
       # logger.warning(f"Different labels found for {term}. Uberongraph: {label} ; ASCT+b table: {row['slabel']}")
       ccf_tools_df.loc[(ccf_tools_df['s'] == term), 'slabel'] = label
       ccf_tools_df.loc[(ccf_tools_df['o'] == term), 'olabel'] = label
         
     if row['o'] == term and row['olabel'].lower() != label.lower():
-      log_dict["diff_label"].append({"id": term, "label": label, "asct_label": row['olabel'], "user_label": row['user_olabel'], "rowNumber": int(row['row_number'])})
+      log_dict["diff_label"].append({"id": term, "label": label, "asct_label": row['olabel'], "user_label": row['user_olabel'], "row_number": int(row['row_number'])})
       # logger.warning(f"Different labels found for {term}. Uberongraph: {label} ; ASCT+b table: {row['olabel']}")
       ccf_tools_df.loc[(ccf_tools_df['o'] == term), 'olabel'] = label
       ccf_tools_df.loc[(ccf_tools_df['s'] == term), 'slabel'] = label


### PR DESCRIPTION
Instead of having one entry for each row, now the reports show the list of rows for the same issue.

For example, in the Blank Ontology ID report:

1. No term id was found for the name/label intramural segment of Fallopian tube in the following 24 rows: 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 77, 78, 104, 105, 106, 107, 121, 122.