### PR TITLE
Split queries in chunks when table is big

### DIFF
--- a/src/template_generation_tools.py
+++ b/src/template_generation_tools.py
@@ -94,7 +94,11 @@ def generate_class_graph_template(ccf_tools_df :pd.DataFrame, log_dict: dict):
     terms.add(r['o'])
 
   # ENTITY CHECK
-  no_valid_class = ug.query_uberon(" ".join(terms), ug.select_class)
+  if len(terms) > 90:
+    for chunk in chunks(list(terms), 90):
+      no_valid_class = ug.query_uberon(" ".join(chunk), ug.select_class)
+  else:
+    no_valid_class = ug.query_uberon(" ".join(chunk), ug.select_class)
 
   del_index = []
   for t in no_valid_class:

--- a/src/uberongraph_tools.py
+++ b/src/uberongraph_tools.py
@@ -473,10 +473,19 @@ class UberonGraph():
         
 
       if len(terms_ct_d) > 20:
-        for chunk in chunks(list(terms_ct_d), 30):
-          sec_graph += self.construct_relation(subject="\n".join(chunk), objects="\n".join(list(all_ct)), property="rdfs:subClassOf")
+        for chunk in chunks(list(terms_ct_d), 20):
+          if len(all_ct) > 90:
+            for chunck in chunks(list(all_ct), 90):
+              sec_graph += self.construct_relation(subject="\n".join(chunk), objects="\n".join(list(chunck)), property="rdfs:subClassOf")
+          else:
+            sec_graph += self.construct_relation(subject="\n".join(chunk), objects="\n".join(list(all_ct)), property="rdfs:subClassOf")
       else:
-        sec_graph += self.construct_relation(subject="\n".join(terms_ct_d), objects="\n".join(list(all_ct)), property="rdfs:subClassOf")
+        if len(all_ct) > 90:
+            for chunck in chunks(list(all_ct), 90):
+              sec_graph += self.construct_relation(subject="\n".join(terms_ct_d), objects="\n".join(list(chunck)), property="rdfs:subClassOf")
+        else:
+          sec_graph += self.construct_relation(subject="\n".join(terms_ct_d), objects="\n".join(list(all_ct)), property="rdfs:subClassOf")
+        
 
       return sec_graph
 


### PR DESCRIPTION
There are more than 700 terms in the Brain table and now we need to work in chunks when verifying if class exists and when constructing suggestion graph.