### PR TITLE
Add mouth graphs to GRAPH_NAME_LIST

### DIFF
--- a/src/hra_wrapper.py
+++ b/src/hra_wrapper.py
@@ -42,6 +42,8 @@ GRAPH_NAME_LIST = [
     "main-bronchus-male",
     "mammary-gland-female-left",
     "mammary-gland-female-right",
+    "mouth-female",
+    "mouth-male",
     "ovary-female-left",
     "ovary-female-right",
     "palatine-tonsil-female-left",


### PR DESCRIPTION
Added 'mouth-female' and 'mouth-male' entries to the GRAPH_NAME_LIST to support new anatomical graph types.